### PR TITLE
Restore ability to use DEBUG_URI when DEBUG is true

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -29,13 +29,15 @@ server.listen(process.env.PORT || 3978, () => {
 const connector = new BotFrameworkAdapter({ appId: process.env.MICROSOFT_APP_ID, appPassword: process.env.MICROSOFT_APP_PASSWORD });
 server.post('/api/messages', connector.listen() as any);
 
+const useDebug = process.env.BLIS_DEBUG.toLowerCase() === 'true'
+const serviceUri = useDebug ? process.env.BLIS_DEBUG_URI : process.env.BLIS_SERVICE_URI
 const blisOptions: IBlisOptions = {
-    serviceUri: process.env.BLIS_SERVICE_URI,
+    serviceUri,
     appId: process.env.BLIS_APP_ID,
     azureFunctionsUrl: process.env.BLIS_FUNCTIONS_URL,
     redisServer: process.env.BLIS_REDIS_SERVER,
     redisKey: process.env.BLIS_REDIS_KEY,
-    localhost: process.env.BLIS_LOCALHOST.toLowerCase() == 'true',
+    localhost: process.env.BLIS_LOCALHOST.toLowerCase() === 'true',
     user: process.env.BLIS_USER,
     secret: process.env.BLIS_SECRET
 }


### PR DESCRIPTION
Accidentally removed this when allowing configuration of PORTS / URIs