### PR TITLE
 Clarify that microsoft app id and app password are not used by BLIS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -18,10 +18,11 @@ server.listen(process.env.port || process.env.PORT || config.botPort, () => {
     console.log(`${server.name} listening to ${server.url}`);
 });
 
+const { microsoftAppId, microsoftAppPassword, ...blisConfig } = config
 //==================
 // Create connector
 //==================
-const connector = new BotFrameworkAdapter({ appId: config.microsoftAppId, appPassword: config.microsoftAppPassword });
+const connector = new BotFrameworkAdapter({ appId: microsoftAppId, appPassword: microsoftAppPassword });
 server.post('/api/messages', connector.listen() as any);
 
 //==================================
@@ -30,7 +31,7 @@ server.post('/api/messages', connector.listen() as any);
 // Initialize Blis using file storage.  Recommended only for development
 // See "storageDemo.ts" for other storage options
 let fileStorage = new FileStorage( {path: path.join(__dirname, 'storage')})
-Blis.Init(config, fileStorage);
+Blis.Init(blisConfig, fileStorage);
 
 //=================================
 // Add Entity Logic


### PR DESCRIPTION
Lucas mentioned this could confuse people so this should make it clearer.

Fixes VSTS#1063

