### PR TITLE
Remove duplicate reference to {question} in card

### DIFF
--- a/cards/prompt.json
+++ b/cards/prompt.json
@@ -2,7 +2,7 @@
     "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
     "type": "AdaptiveCard",
     "version": "1.0",
-    "speak": "{{question}}",
+    "speak": "{{speak}}",
     "body": [
       {
         "type": "TextBlock",


### PR DESCRIPTION
Fixing a bug I introduced previously (when removing copy-pasted text from "speak" field of card)