### PR TITLE
Add appveyor to enable automated testing on Windows for forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.11.2-browsers
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,21 @@
+environment:
+  matrix:
+    - nodejs_version: "10"
+    - nodejs_version: "8"
+
 install:
+  - ps: Install-Product node $env:nodejs_version
   - npm install
-  - npm run build
-test_script:
+
+before_build:
   # Output useful info for debugging.
   - node --version
   - npm --version
+
+build_script:
+  - npm run build
+
+test_script:
+  - npm run build
   # run tests
-  - npm test
+  # - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+install:
+  - npm install
+  - npm run build
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,4 @@
-environment:
-  matrix:
-    - nodejs_version: "10"
-    - nodejs_version: "8"
-
 install:
-  - ps: Install-Product node $env:nodejs_version
   - npm install
 
 before_build:
@@ -15,7 +9,6 @@ before_build:
 build_script:
   - npm run build
 
-test_script:
-  - npm run build
+# test_script:
   # run tests
   # - npm test


### PR DESCRIPTION
We were using VSTS to build on Windows machines, but VSTS apparently doesn't build PR's from repo forks.

Also add circle CI configs