### PR TITLE
update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Set NODE environment. When development the SDK and DOL (Direct Offline) will be exposed on your bot to support model editing.
+# Do NOT set 'development' when in production
 NODE_ENV=development
 
 # LUIS Authoring key is required and is used for all LUIS model change operations and training
@@ -13,16 +15,11 @@ LUIS_SUBSCRIPTION_KEY=
 # the field "App ID".
 CONVERSATION_LEARNER_MODEL_ID=
 
-# Optionally configure absolute URI to Conversation Learner cloud service where machine learning is done
-# Can be used to target different API versions for testing pre-release features
-CONVERSATION_LEARNER_SERVICE_URI=https://westus.api.cognitive.microsoft.com/conversationlearner/v1.0/
-
-# Optionally Configure various ports for locally running services
-# to avoid conflicts with other locally running services
-CONVERSATION_LEARNER_UI_PORT=5050
+# Optionally Configure UI port to avoid conflicts with other locally running services
+# CONVERSATION_LEARNER_UI_PORT=5050
 
 # By default @conversationlearner/sdk will store Bot memory/state in local memory storage.
 # To run the Redis storage demo (demoStorage.ts) add the server uri and key
-CONVERSATION_LEARNER_REDIS_SERVER=
-CONVERSATION_LEARNER_REDIS_KEY=
+# CONVERSATION_LEARNER_REDIS_SERVER=
+# ONVERSATION_LEARNER_REDIS_KEY=
 


### PR DESCRIPTION
Update descriptions and comments in .env.example

You really only need two variables for development/training:
```
NODE_ENV=development
LUIS_AUTHORING_KEY=<removed>
```
then when deploying for production you will have different set of variables on the environment:
```
LUIS_SUBSCRIPTION_KEY=
CONVERSATIONLEARNER_MODEL_ID=

# Optionally
CONVERSATION_LEARNER_REDIS_SERVER=
CONVERSATION_LEARNER_REDIS_KEY=
```
