### PR TITLE
fix: conversation ref missing in emulator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,9 @@
       "integrity": "sha512-cIlHwmkoraF48vRHkyHa9JB4QiLQwSDk1EFzoMFBnQSM7ueY6ZFFRuYSYjlKLKxO4TXfLDaaumHT9Te5T0iveA=="
     },
     "@conversationlearner/sdk": {
-      "version": "0.274.9",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/sdk/-/sdk-0.274.9.tgz",
-      "integrity": "sha512-xyNYNhn+edd2nV2AlBhxdgJlc8QsrDlAqfEbOFxbseBnwc6tSSD+9i8WnCwMym/3uX6jLtPP/SPkckiU0G6uvw==",
+      "version": "0.274.10",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/sdk/-/sdk-0.274.10.tgz",
+      "integrity": "sha512-jrwdo9beITwwc0rkP9DGMVn/c5VjK9zHogWP7CT/E9GBaaujsNhqlgmVAeym9rJMbeZO+RPfX4g2ATmDDAbVRw==",
       "requires": {
         "@conversationlearner/models": "0.170.1",
         "@conversationlearner/ui": "0.295.13",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "Microsoft Conversation Learner Team",
   "license": "MIT",
   "dependencies": {
-    "@conversationlearner/sdk": "0.274.9",
+    "@conversationlearner/sdk": "0.274.10",
     "botbuilder": "4.0.0-preview1.2",
     "convict": "^4.0.2",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
Using the emulator (with model ID set in config) empty storage resulted in having missing conversation reference error as the conversation ref was being cleared when the app was set. Fixed in SDK