### PR TITLE
Demonstrate using uiRouter and serving UI at /ui path of Bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,6 @@ LUIS_SUBSCRIPTION_KEY=
 # the field "CONVERSATION_LEARNER_MODEL_ID".
 CONVERSATION_LEARNER_MODEL_ID=
 
-# Optionally Configure UI port to avoid conflicts with other locally running services
-# CONVERSATION_LEARNER_UI_PORT=5050
-
 # By default @conversationlearner/sdk will store Bot memory/state in local memory storage.
 # To run the Redis storage demo (demoStorage.ts) add the server uri and key
 # CONVERSATION_LEARNER_REDIS_SERVER=

--- a/README.md
+++ b/README.md
@@ -66,15 +66,7 @@ Project Conversation Learner consists of an SDK you add to your bot, and a cloud
 
     This runs the generic empty bot in `my-bot-01/src/app.ts`.
 
-3. Run Conversation Learner UI:
-
-    ```bash
-    [open second command prompt window]
-    cd my-bot-01
-    npm run ui
-    ```
-
-4. Open browser to http://localhost:5050 
+3. Open browser to http://localhost:3978
 
 You're now using Conversation Learner and can create and teach a Conversation Learner model.  
 
@@ -82,9 +74,9 @@ You're now using Conversation Learner and can create and teach a Conversation Le
 
 The instructions above started the generic empty bot.  To run a tutorial or demo bot instead:
 
-1. If you have the Conversation Learner web UI open, return to the list of models at http://localhost:5050/home.
+1. If you have the Conversation Learner web UI open, return to the list of models at http://localhost:3978/ui/home.
     
-2. If another bot is running (like `npm start` or `npm run demo-pizza`), stop it.  You do not need to stop the UI process, or close the web browser.
+2. If another bot is running (like `npm start` or `npm run demo-pizza`), stop it.  You do not need close the web browser.
 
 3. Run a demo bot from the command line (step 2 above).  Demos include:
 
@@ -99,7 +91,7 @@ The instructions above started the generic empty bot.  To run a tutorial or demo
   npm run demo-vrapp
   ```
 
-4. If you're not already, switch to the Conversation Learner web UI in Chrome by loading http://localhost:5050/home. 
+4. If you're not already, switch to the Conversation Learner web UI in Chrome by loading http://localhost:3978/ui/home. 
 
 5. Click on "Import tutorials" (only needs to be done once).  This will take about a minute and will copy the Conversation Learner models for all the tutorials into your Conversation Learner account.
 
@@ -109,9 +101,9 @@ Source files for the demos are in `my-bot-01/src/demos`
 
 ## Create a bot which includes back-end code
 
-1. If you have the Conversation Learner web UI open, return to the list of models at http://localhost:5050/home.
+1. If you have the Conversation Learner web UI open, return to the list of models at http://localhost:3978/ui/home.
     
-2. If a bot is running (like `npm run demo-pizza`), stop it.  You do not need to stop the UI process, or close the web browser.
+2. If a bot is running (like `npm run demo-pizza`), stop it.  You do not need to close the web browser.
 
 3. If desired, edit code in `my-bot-01/src/app.ts`.
 
@@ -122,7 +114,7 @@ Source files for the demos are in `my-bot-01/src/demos`
     npm start
     ```
 
-5. If you're not already, switch to the Conversation Learner web UI in Chrome by loading http://localhost:5050/home. 
+5. If you're not already, switch to the Conversation Learner web UI in Chrome by loading http://localhost:3978/ui/home. 
 
 6. Create a new Conversation Learner application in the UI, and start teaching.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "pretest": "npm run build",
     "test": "jest",
     "tsc": "tsc",
-    "ui": "node ./lib/ui.js",
     "verifypackagelock": "tsc -p ./scripts/tsconfig.json && node ./scripts/verifypackagelock.js",
     "watch": "concurrently --kill-others -p [{name}-{pid}] -n tsc,bot \"tsc -w\" \"nodemon\"",
     "demo-password": "node ./lib/demos/demoPasswordReset.js",

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Bot Summary</title>
+
+    <style type="text/css">
+        body {
+            text-align: center
+        }    
+    </style>
+</head>
+<body>
+    <h1>Sample Bot Summary Page</h1>
+
+    <p>Here you can show basic information about your bot.  It can serve as a homepage for your bot.</p>
+
+    <p>This the sample empty-bot included on Conversation Learner.</p>
+
+    <h2>Go to UI: <a href="http://localhost:3978/ui">http://localhost:3978/ui</a></h2>
+</body>
+</html>

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -13,6 +13,11 @@ describe('Test bot server', () => {
         expect(response.status).toBe(200)
     })
 
+    it('given request to known (ui) route should return 200', async () => {
+        const response = await botServer.get('/ui/home')
+        expect(response.status).toBe(200)
+    })
+
     it('given request to unknown route should return 404', async () => {
         const response = await botServer.get('/unknown')
         expect(response.status).toBe(404)

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@
 import * as path from 'path'
 import * as express from 'express'
 import { BotFrameworkAdapter } from 'botbuilder'
-import { ConversationLearner, ClientMemoryManager, FileStorage } from '@conversationlearner/sdk'
+import { ConversationLearner, ClientMemoryManager, FileStorage, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from './config'
 
@@ -40,7 +40,14 @@ const includeSdk = ['development', 'test'].includes(process.env.NODE_ENV || '')
 if (includeSdk) {
     console.log(chalk.cyanBright(`Adding /sdk routes`))
     server.use('/sdk', sdkRouter)
+
+    // Note: Must be mounted at root to use internal /ui paths
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
+
+console.log(`Serving default bot summary web site.`)
+server.use(express.static(path.join(__dirname, '..', 'site')))
 
 const cl = new ConversationLearner(modelId)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,11 +32,6 @@ export const config = convict({
         default: "https://westus.api.cognitive.microsoft.com/conversationlearner/v1.0/",
         env: 'CONVERSATION_LEARNER_SERVICE_URI'
     },
-    CONVERSATION_LEARNER_UI_PORT: {
-        format: 'port',
-        default: 5050,
-        env: 'CONVERSATION_LEARNER_UI_PORT',
-    },
     modelId: {
         format: String,
         default: undefined,

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,6 @@ if (isDevelopment) {
 }
 
 app.listen(config.botPort, () => {
-    console.log(`Server listening to port: ${config.botPort}`)
+    console.log(`Server listening at: http://localhost:${config.botPort}`)
 })
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,8 +1,0 @@
-/**
- * Copyright (c) Microsoft Corporation. All rights reserved.  
- * Licensed under the MIT License.
- */
-import config from './config'
-import { startUiServer } from '@conversationlearner/sdk'
-
-startUiServer(config.CONVERSATION_LEARNER_UI_PORT)


### PR DESCRIPTION
The user no longer needs to run the separate command `npm run ui` to serve / start the interface.
It is now included with the Bot! This reduces and extra setup step and aligns us more closely with normal BotFramework bots that only have 1 command to start.

We also still allow using the root `/` for the Bot summary page which the developer can customize to their liking and there is an example of this in the `site` folder for the `app.ts` empty bot.

- Remove need for CONVERSATION_LEARNER_UI_PORT
- Update docs to use bot url with path instead of url with port 5050

I will probably work more on the Bot landing / summary page based on what Swadheed recommends.