### PR TITLE
Update build .yml files to only build PR's targeting master or develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 
+branches:
+  only:
+    - master
+    - develop
+
 cache:
   directories:
     - ~/.npm

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,12 @@
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
+skip_tags: true
 
+branches:
+  only:
+    - master
+    - develop
+    
 cache:
   - '%AppData%\npm-cache -> appveyor.yml'
   - '%AppData%\..\Local\Cypress\Cache -> package-lock.json'


### PR DESCRIPTION
Update's `.travis.yml` and `appveyor.yml` to be consistent with other repos.

I think I originally thought we should build all branches so customers could see feedback on their custom branches but they still will even with this change. They would only see the build reports if they created a PR and they would always need to submit a PR anyways so the experience should be similar to them with less stress on build servers.