### PR TITLE
fix: bug 1903 remove endsession action to retain tutorial exercise

### DIFF
--- a/models/Tutorial-13-SessionCallbacks.cl
+++ b/models/Tutorial-13-SessionCallbacks.cl
@@ -1,301 +1,9 @@
 ﻿{
-    "trainDialogs": [
-        {
-            "trainDialogId": "dfa9c9da-e5fa-444f-b942-62b25d00a90e",
-            "rounds": [
-                {
-                    "extractorStep": {
-                        "textVariations": [
-                            {
-                                "text": "hi",
-                                "labelEntities": []
-                            }
-                        ]
-                    },
-                    "scorerSteps": [
-                        {
-                            "input": {
-                                "filledEntities": [
-                                    {
-                                        "entityId": "45e0cd0b-889f-4c14-bdd0-dd3386828791",
-                                        "values": [
-                                            {
-                                                "userText": "Botty",
-                                                "displayText": "Botty",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "context": {},
-                                "maskedActions": []
-                            },
-                            "labelAction": "f6466ecc-a075-4541-bce9-29ddf23765de",
-                            "metrics": {
-                                "predictMetrics": null
-                            }
-                        }
-                    ]
-                },
-                {
-                    "extractorStep": {
-                        "textVariations": [
-                            {
-                                "text": "Lars",
-                                "labelEntities": [
-                                    {
-                                        "entityId": "54e7a247-2111-4c0f-992c-cd31f8d3121f",
-                                        "startCharIndex": 0,
-                                        "endCharIndex": 3,
-                                        "entityText": "Lars"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "scorerSteps": [
-                        {
-                            "input": {
-                                "filledEntities": [
-                                    {
-                                        "entityId": "45e0cd0b-889f-4c14-bdd0-dd3386828791",
-                                        "values": [
-                                            {
-                                                "userText": "Botty",
-                                                "displayText": "Botty",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "54e7a247-2111-4c0f-992c-cd31f8d3121f",
-                                        "values": [
-                                            {
-                                                "userText": "Lars",
-                                                "displayText": "Lars",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "context": {},
-                                "maskedActions": []
-                            },
-                            "labelAction": "ee1000fc-9e0c-4097-9742-715cc5260ed7",
-                            "metrics": {
-                                "predictMetrics": null
-                            }
-                        }
-                    ]
-                },
-                {
-                    "extractorStep": {
-                        "textVariations": [
-                            {
-                                "text": "555-555-5555",
-                                "labelEntities": [
-                                    {
-                                        "entityId": "8f842244-b059-4107-b5b2-c257d9a1c230",
-                                        "startCharIndex": 0,
-                                        "endCharIndex": 11,
-                                        "entityText": "555-555-5555"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "scorerSteps": [
-                        {
-                            "input": {
-                                "filledEntities": [
-                                    {
-                                        "entityId": "45e0cd0b-889f-4c14-bdd0-dd3386828791",
-                                        "values": [
-                                            {
-                                                "userText": "Botty",
-                                                "displayText": "Botty",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "54e7a247-2111-4c0f-992c-cd31f8d3121f",
-                                        "values": [
-                                            {
-                                                "userText": "Lars",
-                                                "displayText": "Lars",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "8f842244-b059-4107-b5b2-c257d9a1c230",
-                                        "values": [
-                                            {
-                                                "userText": "555-555-5555",
-                                                "displayText": "555-555-5555",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "context": {},
-                                "maskedActions": []
-                            },
-                            "labelAction": "d6f7d19a-19be-4d58-9de2-9daaea578480",
-                            "metrics": {
-                                "predictMetrics": null
-                            }
-                        }
-                    ]
-                },
-                {
-                    "extractorStep": {
-                        "textVariations": [
-                            {
-                                "text": "Seattle",
-                                "labelEntities": [
-                                    {
-                                        "entityId": "718df4cd-83ab-4cc0-8959-c83d91f20bd6",
-                                        "startCharIndex": 0,
-                                        "endCharIndex": 6,
-                                        "entityText": "Seattle"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "scorerSteps": [
-                        {
-                            "input": {
-                                "filledEntities": [
-                                    {
-                                        "entityId": "45e0cd0b-889f-4c14-bdd0-dd3386828791",
-                                        "values": [
-                                            {
-                                                "userText": "Botty",
-                                                "displayText": "Botty",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "54e7a247-2111-4c0f-992c-cd31f8d3121f",
-                                        "values": [
-                                            {
-                                                "userText": "Lars",
-                                                "displayText": "Lars",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "8f842244-b059-4107-b5b2-c257d9a1c230",
-                                        "values": [
-                                            {
-                                                "userText": "555-555-5555",
-                                                "displayText": "555-555-5555",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "718df4cd-83ab-4cc0-8959-c83d91f20bd6",
-                                        "values": [
-                                            {
-                                                "userText": "Seattle",
-                                                "displayText": "Seattle",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "context": {},
-                                "maskedActions": []
-                            },
-                            "labelAction": "9ba7ca4e-8cf0-419d-96a5-3987b2b8456b",
-                            "metrics": {
-                                "predictMetrics": null
-                            }
-                        },
-                        {
-                            "input": {
-                                "filledEntities": [
-                                    {
-                                        "entityId": "45e0cd0b-889f-4c14-bdd0-dd3386828791",
-                                        "values": [
-                                            {
-                                                "userText": "Botty",
-                                                "displayText": "Botty",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "54e7a247-2111-4c0f-992c-cd31f8d3121f",
-                                        "values": [
-                                            {
-                                                "userText": "Lars",
-                                                "displayText": "Lars",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "8f842244-b059-4107-b5b2-c257d9a1c230",
-                                        "values": [
-                                            {
-                                                "userText": "555-555-5555",
-                                                "displayText": "555-555-5555",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "entityId": "718df4cd-83ab-4cc0-8959-c83d91f20bd6",
-                                        "values": [
-                                            {
-                                                "userText": "Seattle",
-                                                "displayText": "Seattle",
-                                                "builtinType": null,
-                                                "resolution": null
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "context": {},
-                                "maskedActions": []
-                            },
-                            "labelAction": "9960dc85-b341-4fcf-8152-d08af6b56e45",
-                            "metrics": {
-                                "predictMetrics": null
-                            }
-                        }
-                    ]
-                }
-            ],
-            "initialFilledEntities": [],
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
-            "lastModifiedDateTime": "2018-12-18T23:43:37+00:00"
-        }
-    ],
+    "trainDialogs": [],
     "actions": [
         {
             "actionId": "f6466ecc-a075-4541-bce9-29ddf23765de",
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
+            "createdDateTime": "2019-02-13T17:23:08.2207961+00:00",
             "actionType": "TEXT",
             "payload": "{\"text\":\"Hi, I'm $BotName.  What's your name?\",\"json\":{\"kind\":\"value\",\"document\":{\"kind\":\"document\",\"data\":{},\"nodes\":[{\"kind\":\"block\",\"type\":\"paragraph\",\"isVoid\":false,\"data\":{},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"Hi, I'm \",\"marks\":[]}]},{\"kind\":\"inline\",\"type\":\"mention-inline-node\",\"isVoid\":false,\"data\":{\"completed\":true,\"option\":{\"id\":\"45e0cd0b-889f-4c14-bdd0-dd3386828791\",\"name\":\"BotName\"}},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"$BotName\",\"marks\":[]}]}]},{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\".  What's your name?\",\"marks\":[]}]}]}]}}}",
             "isTerminal": true,
@@ -310,7 +18,7 @@
         },
         {
             "actionId": "ee1000fc-9e0c-4097-9742-715cc5260ed7",
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
+            "createdDateTime": "2019-02-13T17:23:08.2520629+00:00",
             "actionType": "TEXT",
             "payload": "{\"text\":\"Hi $UserName.  What is your phone number?\",\"json\":{\"kind\":\"value\",\"document\":{\"kind\":\"document\",\"data\":{},\"nodes\":[{\"kind\":\"block\",\"type\":\"paragraph\",\"isVoid\":false,\"data\":{},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"Hi \",\"marks\":[]}]},{\"kind\":\"inline\",\"type\":\"mention-inline-node\",\"isVoid\":false,\"data\":{\"completed\":true,\"option\":{\"id\":\"54e7a247-2111-4c0f-992c-cd31f8d3121f\",\"name\":\"UserName\"}},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"$UserName\",\"marks\":[]}]}]},{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\".  What is your phone number?\",\"marks\":[]}]}]}]}}}",
             "isTerminal": true,
@@ -325,7 +33,7 @@
         },
         {
             "actionId": "d6f7d19a-19be-4d58-9de2-9daaea578480",
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
+            "createdDateTime": "2019-02-13T17:23:08.2520629+00:00",
             "actionType": "TEXT",
             "payload": "{\"text\":\"Can you tell $BotName your location, $UserName?\",\"json\":{\"kind\":\"value\",\"document\":{\"kind\":\"document\",\"data\":{},\"nodes\":[{\"kind\":\"block\",\"type\":\"paragraph\",\"isVoid\":false,\"data\":{},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"Can you tell \",\"marks\":[]}]},{\"kind\":\"inline\",\"type\":\"mention-inline-node\",\"isVoid\":false,\"data\":{\"completed\":true,\"option\":{\"id\":\"45e0cd0b-889f-4c14-bdd0-dd3386828791\",\"name\":\"BotName\"}},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"$BotName\",\"marks\":[]}]}]},{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\" your location, \",\"marks\":[]}]},{\"kind\":\"inline\",\"type\":\"mention-inline-node\",\"isVoid\":false,\"data\":{\"completed\":true,\"option\":{\"id\":\"54e7a247-2111-4c0f-992c-cd31f8d3121f\",\"name\":\"UserName\"}},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"$UserName\",\"marks\":[]}]}]},{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"?\",\"marks\":[]}]}]}]}}}",
             "isTerminal": true,
@@ -341,7 +49,7 @@
         },
         {
             "actionId": "9ba7ca4e-8cf0-419d-96a5-3987b2b8456b",
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
+            "createdDateTime": "2019-02-13T17:23:08.2520629+00:00",
             "actionType": "TEXT",
             "payload": "{\"json\":{\"kind\":\"value\",\"document\":{\"kind\":\"document\",\"data\":{},\"nodes\":[{\"kind\":\"block\",\"type\":\"paragraph\",\"isVoid\":false,\"data\":{},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"So, \",\"marks\":[]}]},{\"kind\":\"inline\",\"type\":\"mention-inline-node\",\"isVoid\":false,\"data\":{\"completed\":true,\"option\":{\"id\":\"54e7a247-2111-4c0f-992c-cd31f8d3121f\",\"name\":\"UserName\"}},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"$UserName\",\"marks\":[]}]}]},{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\", you are in \",\"marks\":[]}]},{\"kind\":\"inline\",\"type\":\"mention-inline-node\",\"isVoid\":false,\"data\":{\"completed\":true,\"option\":{\"id\":\"718df4cd-83ab-4cc0-8959-c83d91f20bd6\",\"name\":\"UserLocation\"}},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"$UserLocation\",\"marks\":[]}]}]},{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"\",\"marks\":[]}]}]}]}}}",
             "isTerminal": false,
@@ -354,25 +62,12 @@
                 "718df4cd-83ab-4cc0-8959-c83d91f20bd6"
             ],
             "negativeEntities": []
-        },
-        {
-            "actionId": "9960dc85-b341-4fcf-8152-d08af6b56e45",
-            "createdDateTime": "2018-12-18T23:43:00.7887852+00:00",
-            "actionType": "END_SESSION",
-            "payload": "{\"json\":{\"kind\":\"value\",\"document\":{\"kind\":\"document\",\"data\":{},\"nodes\":[{\"kind\":\"block\",\"type\":\"line\",\"isVoid\":false,\"data\":{},\"nodes\":[{\"kind\":\"text\",\"leaves\":[{\"kind\":\"leaf\",\"text\":\"Done\",\"marks\":[]}]}]}]}}}",
-            "isTerminal": true,
-            "requiredEntitiesFromPayload": [],
-            "requiredEntities": [
-                "54e7a247-2111-4c0f-992c-cd31f8d3121f",
-                "718df4cd-83ab-4cc0-8959-c83d91f20bd6"
-            ],
-            "negativeEntities": []
         }
     ],
     "entities": [
         {
             "entityId": "54e7a247-2111-4c0f-992c-cd31f8d3121f",
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
+            "createdDateTime": "2019-02-13T17:23:08.2207961+00:00",
             "entityName": "UserName",
             "entityType": "LUIS",
             "isMultivalue": false,
@@ -381,7 +76,7 @@
         },
         {
             "entityId": "45e0cd0b-889f-4c14-bdd0-dd3386828791",
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
+            "createdDateTime": "2019-02-13T17:23:08.2207961+00:00",
             "entityName": "BotName",
             "entityType": "LOCAL",
             "isMultivalue": false,
@@ -389,7 +84,7 @@
         },
         {
             "entityId": "8f842244-b059-4107-b5b2-c257d9a1c230",
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
+            "createdDateTime": "2019-02-13T17:23:08.2207961+00:00",
             "entityName": "UserPhone",
             "entityType": "LUIS",
             "isMultivalue": false,
@@ -398,7 +93,7 @@
         },
         {
             "entityId": "718df4cd-83ab-4cc0-8959-c83d91f20bd6",
-            "createdDateTime": "2018-12-18T23:42:06.6050767+00:00",
+            "createdDateTime": "2019-02-13T17:23:08.2207961+00:00",
             "entityName": "UserLocation",
             "entityType": "LUIS",
             "isMultivalue": false,
@@ -406,5 +101,5 @@
             "resolverType": "none"
         }
     ],
-    "packageId": "2f64c1d0-a432-46ae-aafc-da6db4bcdff4"
+    "packageId": "d0eda2ec-2aeb-4793-b366-c633f160f16a"
 }


### PR DESCRIPTION
Session callback tutorial model inadvertently contained an EndSession action. Given creation of the EndSession action is one element of the tutorial, this change cleanly removes the existing endsession action. Removal of the endsession broke the training dialog, so removed the training dialog as well. Docs have the reader building up the training dialog, so no loss in educational value.