### PR TITLE
fix: add /ui routes to all tutorials

### DIFF
--- a/src/demos/demoMultiCL.ts
+++ b/src/demos/demoMultiCL.ts
@@ -5,7 +5,7 @@
 import * as path from 'path'
 import * as express from 'express'
 import { BotFrameworkAdapter, ConversationState, AutoSaveStateMiddleware } from 'botbuilder'
-import { ConversationLearner, ClientMemoryManager, ReadOnlyClientMemoryManager, FileStorage } from '@conversationlearner/sdk'
+import { ConversationLearner, ClientMemoryManager, ReadOnlyClientMemoryManager, FileStorage, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import getDolRouter from '../dol'
@@ -19,6 +19,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+    
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {

--- a/src/demos/demoPasswordReset.ts
+++ b/src/demos/demoPasswordReset.ts
@@ -5,7 +5,7 @@
 import * as path from 'path'
 import * as express from 'express'
 import { BotFrameworkAdapter } from 'botbuilder'
-import { ConversationLearner, FileStorage } from '@conversationlearner/sdk'
+import { ConversationLearner, FileStorage, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import getDolRouter from '../dol'
@@ -19,6 +19,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {

--- a/src/demos/demoPizzaOrder.ts
+++ b/src/demos/demoPizzaOrder.ts
@@ -5,7 +5,7 @@
 import * as path from 'path'
 import * as express from 'express'
 import { BotFrameworkAdapter } from 'botbuilder'
-import { ConversationLearner, ClientMemoryManager, ReadOnlyClientMemoryManager, FileStorage } from '@conversationlearner/sdk'
+import { ConversationLearner, ClientMemoryManager, ReadOnlyClientMemoryManager, FileStorage, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import getDolRouter from '../dol'
@@ -19,6 +19,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+    
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {

--- a/src/demos/demoStorage.ts
+++ b/src/demos/demoStorage.ts
@@ -4,7 +4,7 @@
  */
 import * as express from 'express'
 import { BotFrameworkAdapter } from 'botbuilder'
-import { ConversationLearner, RedisStorage } from '@conversationlearner/sdk'
+import { ConversationLearner, RedisStorage, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import getDolRouter from '../dol'
@@ -18,6 +18,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {

--- a/src/demos/demoVRAppLauncher.ts
+++ b/src/demos/demoVRAppLauncher.ts
@@ -5,7 +5,7 @@
 import * as path from 'path'
 import * as express from 'express'
 import { BotFrameworkAdapter } from 'botbuilder'
-import { ConversationLearner, ClientMemoryManager, FileStorage } from '@conversationlearner/sdk'
+import { ConversationLearner, ClientMemoryManager, FileStorage, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import getDolRouter from '../dol'
@@ -19,6 +19,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {

--- a/src/demos/tutorialAPICalls.ts
+++ b/src/demos/tutorialAPICalls.ts
@@ -4,7 +4,7 @@
  */
 import * as path from 'path'
 import * as express from 'express'
-import { ConversationLearner, ClientMemoryManager, FileStorage, ReadOnlyClientMemoryManager } from '@conversationlearner/sdk'
+import { ConversationLearner, ClientMemoryManager, FileStorage, ReadOnlyClientMemoryManager, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import * as request from 'request'
@@ -21,6 +21,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {

--- a/src/demos/tutorialEntityDetectionCallback.ts
+++ b/src/demos/tutorialEntityDetectionCallback.ts
@@ -5,7 +5,7 @@
 import * as path from 'path'
 import * as express from 'express'
 import { BotFrameworkAdapter } from 'botbuilder'
-import { ConversationLearner, ClientMemoryManager, FileStorage } from '@conversationlearner/sdk'
+import { ConversationLearner, ClientMemoryManager, FileStorage, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import getDolRouter from '../dol'
@@ -19,6 +19,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {

--- a/src/demos/tutorialHybrid.ts
+++ b/src/demos/tutorialHybrid.ts
@@ -6,7 +6,7 @@ import * as path from 'path'
 import * as express from 'express'
 import * as BB from 'botbuilder'
 import { BotFrameworkAdapter, AutoSaveStateMiddleware } from 'botbuilder'
-import { ConversationLearner, ClientMemoryManager, FileStorage, SessionEndState } from '@conversationlearner/sdk'
+import { ConversationLearner, ClientMemoryManager, FileStorage, SessionEndState, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import getDolRouter from '../dol'
@@ -20,6 +20,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {

--- a/src/demos/tutorialSessionCallbacks.ts
+++ b/src/demos/tutorialSessionCallbacks.ts
@@ -6,7 +6,7 @@ import * as path from 'path'
 import * as express from 'express'
 import * as BB from 'botbuilder'
 import { BotFrameworkAdapter } from 'botbuilder'
-import { ConversationLearner, ClientMemoryManager, FileStorage } from '@conversationlearner/sdk'
+import { ConversationLearner, ClientMemoryManager, FileStorage, uiRouter } from '@conversationlearner/sdk'
 import chalk from 'chalk'
 import config from '../config'
 import getDolRouter from '../dol'
@@ -20,6 +20,9 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 if (isDevelopment) {
     console.log(chalk.yellowBright(`Adding /directline routes`))
     server.use(getDolRouter(config.botPort))
+
+    console.log(chalk.greenBright(`Adding /ui routes`))
+    server.use(uiRouter)
 }
 
 server.listen(config.botPort, () => {


### PR DESCRIPTION
Applies the `uiRouter` to all demo/tutorials bots.

In https://github.com/Microsoft/ConversationLearner-Samples/pull/337 we added the /ui route to the empty bot but also needed to add it to all the demos and tutorials.  Previously the interface was shared across of them but now it is part of the bot.

