### PR TITLE
npm audit fixes. note the botbuilder change to match sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,40 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/ms-rest-js": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.2.6.tgz",
+      "integrity": "sha512-8cmDpxsQjVdveJwYKtNnkJorxEORLYJu9UHaUvLZA6yHExzDeISHAcSVWE0J05+VkJtqheVHF17M+2ro18Cdnw==",
+      "requires": {
+        "axios": "^0.18.0",
+        "form-data": "^2.3.2",
+        "tough-cookie": "^2.4.3",
+        "tslib": "^1.9.2",
+        "uuid": "^3.2.1",
+        "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -38,16 +72,16 @@
       "integrity": "sha512-aseNRyydONbh+As8zroqX4AAO0ulFuvJ7ZV/kRH1DOUjwAINo/RgoMpbPzVzn32TCYU4Ge2RMxJG0Ft11fKEPg=="
     },
     "@conversationlearner/sdk": {
-      "version": "0.319.10",
-      "resolved": "https://registry.npmjs.org/@conversationlearner/sdk/-/sdk-0.319.10.tgz",
-      "integrity": "sha512-pr6qddsV0jvURPGnYJ1Vla3lLzHHXZDkqhePdBvLnfN2KnFyLERskR1cNTTkNS0LJ3LKLVJ1DAF4ovQ0JqUbRQ==",
+      "version": "0.319.11",
+      "resolved": "https://registry.npmjs.org/@conversationlearner/sdk/-/sdk-0.319.11.tgz",
+      "integrity": "sha512-ZCiWKSog0YHNIY18LAGyiYJ/Uw/o7AquSX0oOnEpbc/9yCEGG2VkGLaw7VCZ3Mm3tgJdKiYY/ZHzTzc7YaNrjQ==",
       "requires": {
         "@conversationlearner/models": "0.200.3",
         "@conversationlearner/ui": "0.361.4",
         "@types/supertest": "2.0.4",
         "async-file": "^2.0.2",
         "body-parser": "1.18.3",
-        "botbuilder": "4.1.7",
+        "botbuilder": "4.4.0",
         "cors": "2.8.4",
         "express": "4.16.3",
         "filenamify": "^2.0.0",
@@ -58,7 +92,7 @@
         "request": "^2.79.0",
         "semver": "^5.5.0",
         "supertest": "3.1.0",
-        "swagger-client": "^2.1.32",
+        "swagger-client": "3.9.0",
         "tslib": "^1.5.0",
         "typedoc": "0.14.2",
         "url": "0.11.0",
@@ -105,6 +139,11 @@
       "resolved": "https://registry.npmjs.org/@conversationlearner/ui/-/ui-0.361.4.tgz",
       "integrity": "sha512-G3L76kWHlLOK8llNlhNHHmGEw8H3zbJcjBM/73BnyIIB9Nch90OOF8oewJZrnG2TXRKEK+XuehjVIhEBEy8wRA=="
     },
+    "@kyleshockey/object-assign-deep": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@kyleshockey/object-assign-deep/-/object-assign-deep-0.4.2.tgz",
+      "integrity": "sha1-hJAPDu/DcnmPR1G1JigwuCCJIuw="
+    },
     "@types/bluebird": {
       "version": "3.5.20",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
@@ -124,7 +163,8 @@
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "http://registry.npmjs.org/@types%2fcaseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
+      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A==",
+      "dev": true
     },
     "@types/chalk": {
       "version": "2.2.0",
@@ -192,14 +232,18 @@
       }
     },
     "@types/filenamify": {
-      "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/@types%2ffilenamify/-/filenamify-2.0.1.tgz",
-      "integrity": "sha512-QpmNRLMBSQtvd1eV8dodwiUCtSJRhg0EhV+9Xwpch1DhiXPh75qx6aRxVfHvzhQdPzrFJx9v+hpiC0FIVyPQOA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/filenamify/-/filenamify-2.0.2.tgz",
+      "integrity": "sha512-/sO8rlEFYLZGjoDCIy1BmSdo+xNQbtJIgyrElZrzALolPUhBHvY/vQVGKSw4RSkREtuAv3eb6M7mDXvhpFxYbw==",
+      "requires": {
+        "filenamify": "*"
+      }
     },
     "@types/form-data": {
       "version": "2.2.1",
       "resolved": "http://registry.npmjs.org/@types%2fform-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -285,6 +329,7 @@
       "version": "2.47.0",
       "resolved": "http://registry.npmjs.org/@types%2frequest/-/request-2.47.0.tgz",
       "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
+      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -341,7 +386,8 @@
     "@types/tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
+      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==",
+      "dev": true
     },
     "abab": {
       "version": "2.0.0",
@@ -484,10 +530,11 @@
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "http://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "requires": {
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       }
     },
@@ -495,6 +542,11 @@
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -508,9 +560,12 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "requires": {
+        "lodash": "^4.17.11"
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -520,33 +575,10 @@
     },
     "async-file": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/async-file/-/async-file-2.0.2.tgz",
       "integrity": "sha1-Aq0HhWrDcX6DayCuxaTP4AxG3yM=",
       "requires": {
         "rimraf": "^2.5.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        }
       }
     },
     "async-limiter": {
@@ -576,12 +608,19 @@
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
       }
     },
     "babel-code-frame": {
@@ -735,7 +774,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -844,6 +882,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
     "base64url": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -894,74 +937,87 @@
       }
     },
     "botbuilder": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.1.7.tgz",
-      "integrity": "sha512-AlZhvjeqiCpeWGN1TkqBi09l6f0spYIh0Xzc4rJYF8feCFi4k2FEYC1IpiiOAtYhEBeQ9SOGFcUUwPaLmsI3Xg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.4.0.tgz",
+      "integrity": "sha512-M3CIDjAwkOKjcxas7EahZujEIdVPc1BWS+l52DD9WNc8OL9cRMMnYVxNOCmT50CoyJ9MSEYYLJi0X3B3TVhOvQ==",
       "requires": {
         "@types/filenamify": "^2.0.1",
-        "@types/node": "^9.3.0",
-        "async-file": "^2.0.2",
-        "botbuilder-core": "^4.1.7",
-        "botframework-connector": "^4.1.7",
+        "@types/node": "^10.12.18",
+        "botbuilder-core": "^4.4.0",
+        "botframework-connector": "^4.4.0",
         "filenamify": "^2.0.0",
-        "rimraf": "^2.6.2"
+        "fs-extra": "^7.0.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.39.tgz",
-          "integrity": "sha512-c3OkjgNpSMdHan56WhklP0FMOk5ocilKz2Mpa0NOGzu8jw5YERjCf9FG0epYB1+TxScv/oI4uJ204u2mUg7Hcw=="
+          "version": "10.14.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
+          "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg=="
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
         }
       }
     },
     "botbuilder-core": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.1.7.tgz",
-      "integrity": "sha512-kfNOOpHVDLNdpYVMAefWjETXI4VsnDHgucEfKgANcCUrXmsYETlioHOCngUWLrFcaeVMJodeZvafIYl5NTgy0A==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.4.0.tgz",
+      "integrity": "sha512-j2UdMhPTci1Go+Onr0jIN0PGn3TmWbQTyp+5qN+ffwc03MWcPiemV8d/+k8m8ewn59Q1h3u0aEQ4JiKR6egGQA==",
       "requires": {
         "assert": "^1.4.1",
-        "botframework-schema": "^4.1.7"
+        "botframework-schema": "^4.4.0"
       }
     },
     "botframework-connector": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.1.7.tgz",
-      "integrity": "sha512-aIGY0acc/cMxmg1o+06HqReOjNC8qxbmPJDg+wDgaAwr85bSrDZE1CbyITcj2OqPG/QQ7VM3YzpPAZPlKkDWoQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.4.0.tgz",
+      "integrity": "sha512-BXI6wyQE9aqpfWkGNBmD9/M7rk+fXIMII+1iKu1FD9bsxSiJvuvq1wz5pCmzhRjfB3hjg8114V3tZHvMPFEErg==",
       "requires": {
+        "@azure/ms-rest-js": "1.2.6",
         "@types/jsonwebtoken": "7.2.8",
-        "@types/node": "^9.3.0",
-        "@types/request": "^2.47.0",
+        "@types/node": "^10.12.18",
         "base64url": "^3.0.0",
-        "botframework-schema": "^4.1.7",
+        "botframework-schema": "^4.4.0",
+        "form-data": "^2.3.3",
         "jsonwebtoken": "8.0.1",
-        "ms-rest-azure-js": "1.0.176",
-        "ms-rest-js": "1.0.455",
-        "request": "^2.87.0",
+        "nock": "^10.0.3",
+        "node-fetch": "^2.2.1",
         "rsa-pem-from-mod-exp": "^0.8.4"
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.39.tgz",
-          "integrity": "sha512-c3OkjgNpSMdHan56WhklP0FMOk5ocilKz2Mpa0NOGzu8jw5YERjCf9FG0epYB1+TxScv/oI4uJ204u2mUg7Hcw=="
+          "version": "10.14.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
+          "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg=="
+        },
+        "form-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.4.0.tgz",
+          "integrity": "sha512-4FinE8RfqYnNim20xDwZZE0V2kOs/AuElIjFUbPuegQSaoZM+vUT5FnwSl10KPugH4voTg1bEQlcbCG9ka75TA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         }
       }
     },
     "botframework-schema": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.1.7.tgz",
-      "integrity": "sha512-vPb5gHldmTIpUFx5uCdv/4XEsouMkXvSfQS2zsAC3VqAo29YESHYzNbr5HecRaUveb48NZ27+Djm0U0mLFxe9Q==",
-      "requires": {
-        "@types/node": "^9.3.0",
-        "ms-rest-js": "1.0.455"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "9.6.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.39.tgz",
-          "integrity": "sha512-c3OkjgNpSMdHan56WhklP0FMOk5ocilKz2Mpa0NOGzu8jw5YERjCf9FG0epYB1+TxScv/oI4uJ204u2mUg7Hcw=="
-        }
-      }
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.4.0.tgz",
+      "integrity": "sha512-3BWQEbArzHkw49BCdyNxqmSnLzkrL396Q0c+VcdabT3t75wV+dc4bwzSBuLfG0KW+fBjhSR4BXM8IQfnIZU0Vg=="
     },
     "boxen": {
       "version": "1.3.0",
@@ -1047,13 +1103,22 @@
       }
     },
     "btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.1.2.tgz",
+      "integrity": "sha1-PkC4FmP4HS3WWWpMtxSo3BbPq+A="
+    },
+    "buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
@@ -1120,6 +1185,19 @@
       "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -1147,6 +1225,11 @@
           }
         }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "chokidar": {
       "version": "2.0.3",
@@ -1458,8 +1541,7 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1482,6 +1564,22 @@
       "dev": true,
       "requires": {
         "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cross-fetch": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-0.0.8.tgz",
+      "integrity": "sha1-Ae2U3EB98sAPGAf95wCnz6SKIFw=",
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.3"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        }
       }
     },
     "cross-spawn": {
@@ -1573,11 +1671,23 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-extend": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
-      "dev": true
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1727,9 +1837,9 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
-      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -1738,6 +1848,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encode-3986": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/encode-3986/-/encode-3986-1.0.0.tgz",
+      "integrity": "sha1-lA1RSY+HQa3hhLda0UObMXwMemA="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -1831,7 +1946,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -2117,6 +2233,14 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
+    "fast-json-patch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-2.1.0.tgz",
+      "integrity": "sha512-PipOsAKamRw7+CXtKiieehyjUeDVPJ5J7b2kdJYerEf6TSUQoD2ijpVyZ88KQm5YXziff4h762bz3+vzf56khg==",
+      "requires": {
+        "deep-equal": "^1.0.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2145,13 +2269,13 @@
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
     },
     "filenamify": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/filenamify/-/filenamify-2.0.0.tgz",
-      "integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -2851,6 +2975,11 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -3160,6 +3289,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore-by-default": {
       "version": "1.0.1",
@@ -3546,6 +3680,26 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "isomorphic-form-data": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-0.0.1.tgz",
+      "integrity": "sha1-Am9ifgMrDNhBPsyHVZKLlKRosGI=",
+      "requires": {
+        "form-data": "^1.0.0-rc3"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+          "requires": {
+            "async": "^2.0.1",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
+          }
+        }
       }
     },
     "isstream": {
@@ -4490,6 +4644,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4571,7 +4726,7 @@
     },
     "jsonwebtoken": {
       "version": "8.0.1",
-      "resolved": "http://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.0.1.tgz",
       "integrity": "sha1-UNrvjQqMfeLNBrwQE7dbBMzz8M8=",
       "requires": {
         "jws": "^3.1.4",
@@ -4598,21 +4753,21 @@
       }
     },
     "jwa": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
-      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.10",
+        "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
-        "jwa": "^1.1.5",
+        "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4703,11 +4858,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
-    "lodash-compat": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.2.tgz",
-      "integrity": "sha1-xpQBKKnTD46QLNLPmf0Muk7PwYM="
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "http://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -4715,37 +4865,37 @@
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "http://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "http://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "http://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "http://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
@@ -4946,7 +5096,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -4960,56 +5109,6 @@
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "ms-rest-azure-js": {
-      "version": "1.0.176",
-      "resolved": "https://registry.npmjs.org/ms-rest-azure-js/-/ms-rest-azure-js-1.0.176.tgz",
-      "integrity": "sha512-qtEBpSf/1nJ0/m1jGLkHISRnpOeHUp5n4SvzZRdFeYnGF4SQx9v/fl8a8ZwEmyujmgbUwyLNM9qKpH5PmW7pZg==",
-      "requires": {
-        "ms-rest-js": "^1.0.443",
-        "tslib": "^1.9.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-        }
-      }
-    },
-    "ms-rest-js": {
-      "version": "1.0.455",
-      "resolved": "https://registry.npmjs.org/ms-rest-js/-/ms-rest-js-1.0.455.tgz",
-      "integrity": "sha512-RUDnFFNhk4ZdvOACg0yfaxmp5OzNwUcTIwgh/rVBeuNzgA7hOoVh5zFW06XmOtaBHXL2Bu/vWoQtzloEUlv9tw==",
-      "requires": {
-        "axios": "^0.18.0",
-        "form-data": "^2.3.2",
-        "tough-cookie": "^2.4.3",
-        "tslib": "^1.9.2",
-        "uuid": "^3.2.1",
-        "xml2js": "^0.4.19"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        },
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-        }
-      }
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -5045,6 +5144,37 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
       "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
+    },
+    "nock": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "node-fetch": {
       "version": "1.7.3",
@@ -5484,6 +5614,11 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -5600,6 +5735,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+    },
     "proxy-addr": {
       "version": "2.0.3",
       "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
@@ -5625,9 +5765,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
     },
     "pstree.remy": {
       "version": "1.1.0",
@@ -5643,11 +5783,6 @@
       "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
     "qs": {
       "version": "6.5.1",
       "resolved": "http://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -5657,6 +5792,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "querystring-browser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/querystring-browser/-/querystring-browser-1.0.4.tgz",
+      "integrity": "sha1-8uNYgYQKgZvHsb9Zf68JeeZiLcY="
     },
     "randomatic": {
       "version": "3.1.0",
@@ -5878,8 +6018,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -6051,16 +6190,16 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "rsa-pem-from-mod-exp": {
       "version": "0.8.4",
-      "resolved": "http://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/rsa-pem-from-mod-exp/-/rsa-pem-from-mod-exp-0.8.4.tgz",
       "integrity": "sha1-NipCxtMEBW1JOz8SvOq7LGV2ptQ="
     },
     "rsvp": {
@@ -6576,35 +6715,6 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
-    "superagent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
-      "integrity": "sha1-cDUpoHFOV+EjlZ3e+84ZOy5Q0RU=",
-      "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.0.6",
-        "debug": "^2.2.0",
-        "extend": "^3.0.0",
-        "form-data": "1.0.0-rc4",
-        "formidable": "^1.0.17",
-        "methods": "^1.1.1",
-        "mime": "^1.3.4",
-        "qs": "^6.1.0",
-        "readable-stream": "^2.0.5"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "1.0.0-rc4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-          "integrity": "sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=",
-          "requires": {
-            "async": "^1.5.2",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.10"
-          }
-        }
-      }
-    },
     "supertest": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.1.0.tgz",
@@ -6648,16 +6758,38 @@
       "dev": true
     },
     "swagger-client": {
-      "version": "2.2.21",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-2.2.21.tgz",
-      "integrity": "sha1-WWa+I0dyRm5EcW9l4yAIFm2u66Q=",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.9.0.tgz",
+      "integrity": "sha512-uyCq2xoaAtmE0oIQ0fCfnsDoy/v97ANnAZywtyk4yumBP74xXp4NFlpZaqZJHN9K9dbPzgs3MH98VocZeM0ExQ==",
       "requires": {
-        "btoa": "^1.1.2",
-        "cookiejar": "^2.0.1",
-        "js-yaml": "^3.3.0",
-        "lodash-compat": "^3.5.0",
-        "q": "^1.4.1",
-        "superagent": "^2.2"
+        "@kyleshockey/js-yaml": "^1.0.1",
+        "@kyleshockey/object-assign-deep": "^0.4.0",
+        "babel-runtime": "^6.26.0",
+        "btoa": "1.1.2",
+        "buffer": "^5.1.0",
+        "cookie": "^0.3.1",
+        "cross-fetch": "0.0.8",
+        "deep-extend": "^0.5.1",
+        "encode-3986": "^1.0.0",
+        "fast-json-patch": "^2.0.6",
+        "isomorphic-form-data": "0.0.1",
+        "lodash": "^4.16.2",
+        "qs": "^6.3.0",
+        "querystring-browser": "^1.0.4",
+        "traverse": "^0.6.6",
+        "url": "^0.11.0",
+        "utf8-bytes": "0.0.1",
+        "utfstring": "^2.0.0"
+      },
+      "dependencies": {
+        "@kyleshockey/js-yaml": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@kyleshockey/js-yaml/-/js-yaml-1.0.1.tgz",
+          "integrity": "sha512-coFyIk1LvTscq1cUU4nCCfYwv+cmG4fCP+wgDKgYZjhM4f++YwZy+g0k+1tUqa4GuUpBTEOGH2KUqKFFWdT73g==",
+          "requires": {
+            "argparse": "^1.0.7"
+          }
+        }
       }
     },
     "symbol-tree": {
@@ -6897,6 +7029,11 @@
         }
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "tree-kill": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
@@ -6905,7 +7042,7 @@
     },
     "trim-repeated": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
         "escape-string-regexp": "^1.0.2"
@@ -7004,6 +7141,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-is": {
       "version": "1.6.16",
@@ -7254,9 +7396,19 @@
         "kind-of": "^6.0.2"
       }
     },
+    "utf8-bytes": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+      "integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30="
+    },
+    "utfstring": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/utfstring/-/utfstring-2.0.0.tgz",
+      "integrity": "sha512-/ugBfyvIoLe9xqkFHio3CxXnpUKQ1p2LfTxPr6QTRj6GiwpHo73YGdh03UmAzDQNOWpNIE0J5nLss00L4xlWgg=="
+    },
     "util": {
       "version": "0.10.3",
-      "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "requires": {
         "inherits": "2.0.1"
@@ -7509,7 +7661,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmldom": {
@@ -7519,7 +7671,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "author": "Microsoft Conversation Learner Team",
   "license": "MIT",
   "dependencies": {
-    "@conversationlearner/sdk": "0.319.10",
-    "botbuilder": "4.1.7",
+    "@conversationlearner/sdk": "0.319.11",
+    "botbuilder": "4.4.0",
     "chalk": "2.4.1",
     "convict": "^4.0.2",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
Update to `botbuilder` to match latest SDK.

Interesting thought about changing SDK to make botbuilder a peer dependency so it could use whichever version is in the Sample.